### PR TITLE
Issue with getting empt files under NodeJS 6

### DIFF
--- a/helpers/remove.js
+++ b/helpers/remove.js
@@ -73,7 +73,7 @@ module.exports = function(container)
 				//
 				//	5.	Write the page on disk
 				//
-				fs.writeSync(fd, new_file);
+				fs.writeSync(fd, new_file, 0, new_file.length);
 			}
 
 		})

--- a/helpers/remove.js
+++ b/helpers/remove.js
@@ -46,12 +46,14 @@ module.exports = function(container)
 				//
 				let path_to_file = path_to_folder + '/' + file_name;
 
+				console.log("Path to file: ", path_to_file);
+
 				//
 				//	2.	Read the content of the file
 				//
 				let file = fs.readFileSync(path_to_file);
 
-				console.log("From disk: ", file.toString());
+				console.log("From disk: ", file);
 
 				//
 				//	3.	Remove the extension in the a href in the menu of the

--- a/helpers/remove.js
+++ b/helpers/remove.js
@@ -51,11 +51,15 @@ module.exports = function(container)
 				//
 				let file = fs.readFileSync(path_to_file, 'r');
 
+				console.log("From disk: ", new_file.toString());
+
 				//
 				//	3.	Remove the extension in the a href in the menu of the
 				//		page
 				//
 				new_file = file.toString().replace(/\.html/g, '');
+
+				console.log("After cleanup: ",new_file);
 
 				//
 				//	4.	Create a File Descriptor based on the path that we made

--- a/helpers/remove.js
+++ b/helpers/remove.js
@@ -51,7 +51,7 @@ module.exports = function(container)
 				//
 				let file = fs.readFileSync(path_to_file);
 
-				console.log("From disk: ", new_file.toString());
+				console.log("From disk: ", file.toString());
 
 				//
 				//	3.	Remove the extension in the a href in the menu of the
@@ -59,7 +59,7 @@ module.exports = function(container)
 				//
 				new_file = file.toString().replace(/\.html/g, '');
 
-				console.log("After cleanup: ",new_file);
+				console.log("After cleanup: ", new_file);
 
 				//
 				//	4.	Create a File Descriptor based on the path that we made

--- a/helpers/remove.js
+++ b/helpers/remove.js
@@ -49,7 +49,7 @@ module.exports = function(container)
 				//
 				//	2.	Read the content of the file
 				//
-				let file = fs.readFileSync(path_to_file, 'r');
+				let file = fs.readFileSync(path_to_file);
 
 				console.log("From disk: ", new_file.toString());
 

--- a/helpers/remove.js
+++ b/helpers/remove.js
@@ -46,22 +46,16 @@ module.exports = function(container)
 				//
 				let path_to_file = path_to_folder + '/' + file_name;
 
-				console.log("Path to file: ", path_to_file);
-
 				//
 				//	2.	Read the content of the file
 				//
 				let file = fs.readFileSync(path_to_file);
-
-				console.log("From disk: ", file);
 
 				//
 				//	3.	Remove the extension in the a href in the menu of the
 				//		page
 				//
 				new_file = file.toString().replace(/\.html/g, '');
-
-				console.log("After cleanup: ", new_file);
 
 				//
 				//	4.	Create a File Descriptor based on the path that we made

--- a/helpers/render.js
+++ b/helpers/render.js
@@ -256,10 +256,14 @@ function save_to_disk(container)
 			//
 			let file = container.final_files[file_name];
 
+			console.log("Rendered file: ", file);
+
 			//
 			//	2.	Create the file full path
 			//
 			let path = container.settings.dir + '/_input/' + file_name + '.html';
+
+			console.log("Path: ", path);
 
 			//
 			//	3.	Create a File Descriptor based on the path that we made

--- a/helpers/render.js
+++ b/helpers/render.js
@@ -274,7 +274,7 @@ function save_to_disk(container)
 			//
 			//	4.	Write the page on disk
 			//
-			fs.writeSync(fd, file)
+			fs.writeSync(fd, file, 0, file.length);
 		}
 
 		//

--- a/helpers/render.js
+++ b/helpers/render.js
@@ -256,14 +256,10 @@ function save_to_disk(container)
 			//
 			let file = container.final_files[file_name];
 
-			console.log("Rendered file: ", file);
-
 			//
 			//	2.	Create the file full path
 			//
 			let path = container.settings.dir + '/_input/' + file_name + '.html';
-
-			console.log("Path: ", path);
 
 			//
 			//	3.	Create a File Descriptor based on the path that we made

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0x4447/avocado",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "description": "🥑 build the output of a front-end page to be hosted on S3 and delivered by CloudFront",
   "main": "index.js",
   "publishConfig": {


### PR DESCRIPTION
Fixed problem where under NodeJS 6 `fs.writeSync()` will create empty files if you don't specify optional parameters. This is not a problem on NodeJS above 6.